### PR TITLE
feat: Add "djhtml" formatter (indenter) and command

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,14 @@ django templates (htmldjango) extension for [coc.nvim](https://github.com/neocli
 
 ## Features
 
-- Format by [Unibeautify](https://unibeautify.com/) (Beautifiers: JS-Beautify + Pretty Diff)
+- Format (One of them can be selected in the `htmldjango.formatting.provider` settings)
+  - by [Unibeautify](https://unibeautify.com/) (Beautifiers: JS-Beautify + Pretty Diff) [Node tool]
+  - by [DjHTML](https://github.com/rtts/djhtml) ("Django/Jinja" template indenter) [Python tool]
 - Hover | [DEMO](https://github.com/yaegassy/coc-htmldjango/pull/1)
 - Snippets completion
   - To use it, you need to install [coc-snippets](https://github.com/neoclide/coc-snippets).
   - And set `snippets.loadFromExtensions` to true in "coc-settings.json"
+- Built-in installer (DjHTML)
 
 It is possible to use `coc-htmldjango` with filetype other than `htmldjango`.
 
@@ -41,6 +44,10 @@ Plug 'yaegassy/coc-htmldjango', {'do': 'yarn install --frozen-lockfile'}
 ## Configuration options for coc-htmldjango
 
 - `htmldjango.enable`: Enable coc-htmldjango extension, default: `true`
+- `htmldjango.builtin.pythonPath`: Python 3.x path (Absolute path) to be used for built-in install, default: `""`
+- `htmldjango.formatting.provider`: Provider for formatting. Possible options include 'djhtml' and 'unibeautify', default: `"unibeautify"`
+- `htmldjango.djhtml.commandPath`: The custom path to the djhtml (Absolute path), default: `""`
+- `htmldjango.djhtml.tabWidth`: Set tabwidth (--tabwidth), default: `4`
 - `htmldjango.unibeautify.brace_style`: Brace style, valid option `"collapse", "collapse-preserve-inline", "expand", "end-expand", "none"`, default: `"collapse"`
 - `htmldjango.unibeautify.end_with_newline`: End output with newline, default: `true`
 - `htmldjango.unibeautify.force_indentation`: if indentation should be forcefully applied to markup even if it disruptively adds unintended whitespace to the documents rendered output, default: `true`
@@ -60,7 +67,17 @@ Plug 'yaegassy/coc-htmldjango', {'do': 'yarn install --frozen-lockfile'}
 
 ## Commands
 
-- `htmldjango.Format`
+- `htmldjango.unibeautify.format`
+- `htmldjango.djhtml.format`
+- `htmldjango.djhtml.install`
+
+## Bult-in install (DjHTML)
+
+coc-htmldjango allows you to create an extension-only "venv" and install "djhtml".
+
+```vim
+:CocComannd htmldjango.djhtml.install
+```
 
 ## Configuration file for Unibeautify (.unibeautifyrc.{yml,yaml,json})
 
@@ -74,21 +91,26 @@ If there is no configuration file, the default value of `coc-htmldjango` will be
 
 - Files containing `"{% comment %}"` will failed to format
 
-## Related coc.nvim extension
+## Inspiration (Unibeautify or DjHTML)
 
-- [yaegassy/coc-curlylint](https://github.com/yaegassy/coc-curlylint)
-
-## Inspiration
-
-Unfortunately, there is no dedicated formatter tool for "django templates".
+Unfortunately, there is no full formatter tool dedicated to "django templates".
 
 There is no django-specific plugin for prettier either, If you want to use prettier, you need to add lots of "prettier-ignore" comments.
 
-"Visual Studio Code" user community seems to be using `Unibeautify` as a formatter for django templates in many cases, so I created `coc-htmldjango`.
+"Visual Studio Code" user community seems to be using `Unibeautify` as a formatter for django templates in many cases.
+
+---
+
+There seems to be a Python tool called `DjHTML` that is currently under active development.
+
+It seems to be an "indenter", not a full formatter.
+
+I think it's a good tool, so I added a feature to make it available from `coc-htmldjango`.
 
 ## Thanks
 
 - [Unibeautify/unibeautify](https://github.com/Unibeautify/unibeautify)
+- [rtts/djhtml](https://github.com/rtts/djhtml)
 - [vscode-django/vscode-django](https://github.com/vscode-django/vscode-django)
 - [neoclide/coc-snippets](https://github.com/neoclide/coc-snippets)
 - [neoclide/coc-html](https://github.com/neoclide/coc-html)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "coc-htmldjango",
   "version": "0.2.0",
+  "djhtmlVersion": "1.4.6",
   "description": "django templates (htmldjango) extension for coc.nvim. Provides formatter, snippets completion and more...",
   "author": "yaegassy <yosstools@gmail.com>",
   "license": "MIT",
@@ -36,6 +37,9 @@
     "semi": true
   },
   "devDependencies": {
+    "@types/rimraf": "^3.0.0",
+    "@types/which": "^2.0.0",
+    "@types/tmp": "^0.2.0",
     "@types/js-yaml": "^4.0.0",
     "@types/node": "^14.6.3",
     "@typescript-eslint/eslint-plugin": "^4.8.2",
@@ -49,7 +53,9 @@
     "prettier": "^2.2.0",
     "rimraf": "^3.0.2",
     "ts-node": "^9.1.1",
-    "typescript": "^4.1.2"
+    "typescript": "^4.1.2",
+    "which": "^2.0.2",
+    "tmp": "^0.1.0"
   },
   "activationEvents": [
     "onLanguage:htmldjango"
@@ -72,6 +78,31 @@
             "jinja2"
           ],
           "description": "Set the template language to be used for the hover"
+        },
+        "htmldjango.builtin.pythonPath": {
+          "type": "string",
+          "default": "",
+          "description": "Python 3.x path (Absolute path) to be used for built-in install"
+        },
+        "htmldjango.formatting.provider": {
+          "type": "string",
+          "default": "unibeautify",
+          "description": "Provider for formatting. Possible options include 'djhtml' and 'unibeautify'",
+          "enum": [
+            "unibeautify",
+            "djhtml",
+            "none"
+          ]
+        },
+        "htmldjango.djhtml.commandPath": {
+          "type": "string",
+          "default": "",
+          "description": "The custom path to the djhtml (Absolute path)."
+        },
+        "htmldjango.djhtml.tabWidth": {
+          "type": "number",
+          "default": 4,
+          "description": "Set tabwidth (--tabwidth)"
         },
         "htmldjango.unibeautify.brace_style": {
           "type": "string",
@@ -250,8 +281,16 @@
     },
     "commands": [
       {
-        "command": "htmldjango.Format",
-        "title": "Format"
+        "command": "htmldjango.unibeautify.format",
+        "title": "Unibeautify format"
+      },
+      {
+        "command": "htmldjango.djhtml.format",
+        "title": "DjHTML format"
+      },
+      {
+        "command": "htmldjango.djhtml.install",
+        "title": "Install djhtml"
       }
     ],
     "snippets": [

--- a/src/beautifiers.ts
+++ b/src/beautifiers.ts
@@ -1,5 +1,0 @@
-import { Beautifier } from 'unibeautify';
-import prettyDiff from '@unibeautify/beautifier-prettydiff';
-import jsBeautify from '@unibeautify/beautifier-js-beautify';
-
-export const beautifiers: Beautifier[] = [jsBeautify, prettyDiff];

--- a/src/constant.ts
+++ b/src/constant.ts
@@ -1,0 +1,12 @@
+/**
+ * System-wide constants.
+ *
+ * May be read from package.json
+ */
+
+// @ts-ignore
+import { djhtmlVersion } from '../package.json';
+
+export const SUPPORT_LANGUAGES = ['htmldjango'];
+
+export const DJHTML_VERSION = djhtmlVersion;

--- a/src/format.ts
+++ b/src/format.ts
@@ -1,102 +1,22 @@
 import {
   DocumentFormattingEditProvider,
-  DocumentRangeFormattingEditProvider,
+  ExtensionContext,
+  OutputChannel,
   Range,
   TextDocument,
   TextEdit,
-  Uri,
-  window,
   workspace,
 } from 'coc.nvim';
 
-import fs from 'fs';
-import path from 'path';
-import unibeautify, { BeautifyData, OptionValues } from 'unibeautify';
-import yaml from 'js-yaml';
+import { doDjhtmlFormat } from './formatter/djhtml';
+import { doUnibeautifyFormat } from './formatter/unibeautify';
 
-import { beautifiers } from './beautifiers';
-
-export async function doFormat(document: TextDocument, range?: Range): Promise<string> {
-  const extensionConfig = workspace.getConfiguration('htmldjango');
-
-  const fileName = Uri.parse(document.uri).fsPath;
-  const text = document.getText(range);
-
-  let htmlLanguageOptions: OptionValues;
-
-  const configFile = existsConfigFile();
-  if (configFile.exists) {
-    htmlLanguageOptions = loadConfigFile(configFile.filePath, configFile.fileType);
-  } else {
-    htmlLanguageOptions = {
-      brace_style: extensionConfig.get('unibeautify.brace_style'),
-      end_with_newline: extensionConfig.get('unibeautify.end_with_newline'),
-      force_indentation: extensionConfig.get('unibeautify.force_indentation'),
-      indent_comments: extensionConfig.get('unibeautify.indent_comments'),
-      indent_inner_html: extensionConfig.get('unibeautify.indent_inner_html'),
-      indent_scripts: extensionConfig.get('unibeautify.indent_scripts'),
-      indent_size: extensionConfig.get('unibeautify.indent_size'),
-      indent_style: extensionConfig.get('unibeautify.indent_style'),
-      max_preserve_newlines: extensionConfig.get('unibeautify.max_preserve_newlines'),
-      newline_before_tags: extensionConfig.get('unibeautify.newline_before_tags'),
-      preserve_newlines: extensionConfig.get('unibeautify.preserve_newlines'),
-      quotes: extensionConfig.get('unibeautify.quotes'),
-      unformatted: extensionConfig.get('unibeautify.unformatted'),
-      wrap_attributes: extensionConfig.get('unibeautify.wrap_attributes'),
-      wrap_attributes_indent_size: extensionConfig.get('unibeautify.wrap_attributes_indent_size'),
-      wrap_line_length: extensionConfig.get('unibeautify.wrap_line_length'),
-    };
-  }
-
-  unibeautify.loadBeautifiers(beautifiers);
-
-  const beautifyData: BeautifyData = {
-    text,
-    filePath: fileName,
-    projectPath: workspace.root,
-    options: {
-      // https://unibeautify.com/docs/language-html
-      ['HTML']: htmlLanguageOptions,
-    },
-    languageName: 'HTML',
-    fileExtension: '.html',
-  };
-
-  return safeExecution(
-    () => {
-      return unibeautify.beautify(beautifyData);
-    },
-    text,
-    fileName
-  );
-}
-
-function safeExecution(
-  //cb: (() => string) | Promise<string>,
-  cb: () => Promise<string>,
-  defaultText: string,
-  fileName: string
-): string | Promise<string> {
-  if (cb instanceof Promise) {
-    return cb
-      .then((returnValue) => {
-        return returnValue;
-      })
-      .catch((err: Error) => {
-        // eslint-disable-next-line no-console
-        console.error(fileName, err);
-        return defaultText;
-      });
-  }
-
-  try {
-    return cb();
-  } catch (err) {
-    // eslint-disable-next-line no-console
-    console.error(fileName, err);
-    return defaultText;
-  }
-}
+export type FormatFuncType = (
+  context: ExtensionContext,
+  outputChannel: OutputChannel,
+  document: TextDocument,
+  range?: Range
+) => Promise<string>;
 
 export function fullDocumentRange(document: TextDocument): Range {
   const lastLineId = document.lineCount - 1;
@@ -105,8 +25,14 @@ export function fullDocumentRange(document: TextDocument): Range {
   return Range.create({ character: 0, line: 0 }, { character: doc.getline(lastLineId).length, line: lastLineId });
 }
 
-class HtmlDjangoFormattingEditProvider implements DocumentFormattingEditProvider, DocumentRangeFormattingEditProvider {
-  constructor() {}
+class HtmlDjangoFormattingEditProvider implements DocumentFormattingEditProvider {
+  public _context: ExtensionContext;
+  public _outputChannel: OutputChannel;
+
+  constructor(context: ExtensionContext, outputChannel: OutputChannel) {
+    this._context = context;
+    this._outputChannel = outputChannel;
+  }
 
   public provideDocumentFormattingEdits(document: TextDocument): Promise<TextEdit[]> {
     return this._provideEdits(document, undefined);
@@ -116,158 +42,42 @@ class HtmlDjangoFormattingEditProvider implements DocumentFormattingEditProvider
     return this._provideEdits(document, range);
   }
 
-  private async _provideEdits(document: TextDocument, range?: Range): Promise<TextEdit[]> {
-    // To restore the original text in the event of an error
-    let code = document.getText(range);
+  public getFormatFunc(formatter?: string): FormatFuncType {
+    let formatterFunc: FormatFuncType;
 
-    // A bug in prettydiff returns null and causes an error, so try/cacth...
-    try {
-      code = await doFormat(document, range);
-    } catch (e) {
-      // MEMO: Known Bugs
-      // https://github.com/Unibeautify/vscode/issues/197
-      if (code.match(/{% comment %}/)) {
-        window.showErrorMessage('Failed format: Files containing "{% comment %}" (Known bugs in prettydiff)');
-      } else {
-        window.showErrorMessage('Failed format!');
+    // **MEMO**:
+    // Default: unibeautify
+    // Plan to change to djhtml in the future.
+    formatterFunc = doUnibeautifyFormat;
+
+    if (formatter) {
+      if (formatter === 'unibeautify') {
+        formatterFunc = doUnibeautifyFormat;
+      } else if (formatter === 'djhtml') {
+        formatterFunc = doDjhtmlFormat;
+      }
+    } else {
+      const extensionConfig = workspace.getConfiguration('htmldjango');
+      const formattingProvider = extensionConfig.get<string>('formatting.provider', 'unibeautify');
+
+      if (formattingProvider === 'unibeautify') {
+        formatterFunc = doUnibeautifyFormat;
+      } else if (formattingProvider === 'djhtml') {
+        formatterFunc = doDjhtmlFormat;
       }
     }
 
+    return formatterFunc;
+  }
+
+  private async _provideEdits(document: TextDocument, range?: Range): Promise<TextEdit[]> {
+    const doFormat = this.getFormatFunc();
+    const code = await doFormat(this._context, this._outputChannel, document, range);
     if (!range) {
       range = fullDocumentRange(document);
     }
-
     return [TextEdit.replace(range, code)];
   }
-}
-
-interface ExistsConfigFile {
-  exists: boolean;
-  filePath: string;
-  fileType: 'yaml' | 'json' | 'none';
-}
-
-function existsConfigFile(): ExistsConfigFile {
-  const r: ExistsConfigFile = {
-    exists: false,
-    filePath: '',
-    fileType: 'none',
-  };
-
-  const workspaceRootDir = Uri.file(workspace.root).fsPath;
-  if (fs.existsSync(path.join(workspaceRootDir, '.unibeautifyrc.yml'))) {
-    r.exists = true;
-    r.filePath = path.join(workspaceRootDir, '.unibeautifyrc.yml');
-    r.fileType = 'yaml';
-  } else if (fs.existsSync(path.join(workspaceRootDir, '.unibeautifyrc.yaml'))) {
-    r.exists = true;
-    r.filePath = path.join(workspaceRootDir, '.unibeautifyrc.yaml');
-    r.fileType = 'yaml';
-  } else if (fs.existsSync(path.join(workspaceRootDir, '.unibeautifyrc.json'))) {
-    r.exists = true;
-    r.filePath = path.join(workspaceRootDir, '.unibeautifyrc.json');
-    r.fileType = 'json';
-  }
-
-  return r;
-}
-
-function loadConfigFile(filePath: string, fileType: 'yaml' | 'json' | 'none'): OptionValues {
-  let options: OptionValues = {};
-
-  if (!fs.existsSync(filePath) || fileType === 'none') {
-    return options;
-  }
-
-  if (fileType === 'yaml') {
-    try {
-      const configData = yaml.load(fs.readFileSync(filePath, 'utf8'));
-
-      if (configData && typeof configData === 'object') {
-        options = parseConfigData(configData['HTML']);
-      }
-    } catch (e) {
-      return options;
-    }
-  }
-
-  if (fileType === 'json') {
-    try {
-      const configData = JSON.parse(fs.readFileSync(filePath, 'utf8'));
-
-      if (configData && typeof configData === 'object') {
-        options = parseConfigData(configData['HTML']);
-      }
-    } catch (e) {
-      return options;
-    }
-  }
-
-  return options;
-}
-
-function parseConfigData(dataObj: any): OptionValues {
-  // Exclude settings that are not supported by "JS-Beautify, Pretty Diff" from the parse.
-  // https://unibeautify.com/docs/language-html
-  const optionKeyList = [
-    //'align_assignments',
-    //'arrow_parens',
-    'brace_style',
-    //'break_chained_methods',
-    //'comma_first',
-    //'end_of_line',
-    //'end_with_comma',
-    'end_with_newline',
-    //'end_with_semicolon',
-    'force_indentation',
-    //'identifier_case',
-    //'indent_chained_methods',
-    //'indent_char',
-    'indent_comments',
-    'indent_inner_html',
-    //'indent_level',
-    'indent_scripts',
-    'indent_size',
-    'indent_style',
-    //'indent_with_tabs',
-    //'jslint_happy',
-    //'jsx_brackets',
-    //'keep_array_indentation',
-    //'keyword_case',
-    'max_preserve_newlines',
-    //'multiline_ternary',
-    'newline_before_tags',
-    //'newline_between_rules',
-    //'no_leading_zero',
-    //'object_curly_spacing',
-    //'pragma_insert',
-    //'pragma_require',
-    'preserve_newlines',
-    'quotes',
-    //'remove_trailing_whitespace',
-    //'selector_separator_newline',
-    //'space_after_anon_function',
-    //'space_before_conditional',
-    //'space_in_empty_paren',
-    //'space_in_paren',
-    //'typesafe_equality_operators',
-    //'unescape_strings',
-    'unformatted',
-    //'unindent_chained_methods',
-    'wrap_attributes',
-    'wrap_attributes_indent_size',
-    'wrap_line_length',
-    //'wrap_prose',
-  ];
-
-  const options: OptionValues = {};
-  for (const item of optionKeyList) {
-    if (item in dataObj) {
-      options[item] = dataObj[item];
-    }
-  }
-
-  return options;
 }
 
 export default HtmlDjangoFormattingEditProvider;

--- a/src/formatter/djhtml.ts
+++ b/src/formatter/djhtml.ts
@@ -1,0 +1,75 @@
+import { ExtensionContext, OutputChannel, Range, TextDocument, Uri, workspace, window } from 'coc.nvim';
+
+import cp from 'child_process';
+
+import { SUPPORT_LANGUAGES } from '../constant';
+import { resolveDjhtmlPath } from '../tool';
+
+export async function doDjhtmlFormat(
+  context: ExtensionContext,
+  outputChannel: OutputChannel,
+  document: TextDocument,
+  range?: Range
+): Promise<string> {
+  if (!SUPPORT_LANGUAGES.includes(document.languageId)) {
+    throw '"djhtml" cannot run, not supported language';
+  }
+
+  const extensionConfig = workspace.getConfiguration('htmldjango');
+
+  const text = document.getText(range);
+  const fileName = Uri.parse(document.uri).fsPath;
+
+  let djhtmlPath = extensionConfig.get('djhtml.commandPath', '');
+  djhtmlPath = resolveDjhtmlPath(context, djhtmlPath);
+  if (!djhtmlPath) {
+    window.showErrorMessage('Unable to find the "djhtml" command.');
+    return text;
+  }
+
+  const tabwidth = extensionConfig.get('djhtml.tabWidth', 4);
+
+  const args: string[] = [];
+  const cwd = Uri.file(workspace.root).fsPath;
+  // Use shell
+  const opts = { cwd, shell: true };
+
+  args.push('--tabwidth', tabwidth.toString());
+  args.push('-');
+
+  // ---- Output the command to be executed to channel log. ----
+  outputChannel.appendLine(`${'#'.repeat(10)} djhtml\n`);
+  outputChannel.appendLine(`Cwd: ${opts.cwd}`);
+  outputChannel.appendLine(`File: ${fileName}`);
+  outputChannel.appendLine(`Run: ${djhtmlPath} ${args.join(' ')}`);
+
+  return new Promise((resolve) => {
+    const cps = cp.spawn(djhtmlPath, args, opts);
+
+    cps.on('error', (err: Error) => {
+      outputChannel.appendLine(`\n==== ERROR ===\n`);
+      outputChannel.appendLine(`${err}`);
+      return;
+    });
+
+    if (cps.pid) {
+      cps.stdin.write(text);
+      cps.stdin.end();
+
+      cps.stderr.on('data', (data: Buffer) => {
+        outputChannel.appendLine(`\n==== STDERR ===\n`);
+        outputChannel.appendLine(`${data}`);
+
+        // rollback
+        resolve(text);
+      });
+
+      cps.stdout.on('data', (data: Buffer) => {
+        outputChannel.appendLine(`\n==== STDOUT ===\n`);
+        outputChannel.appendLine(`${data}`);
+
+        resolve(data.toString());
+      });
+    }
+  });
+}

--- a/src/formatter/unibeautify.ts
+++ b/src/formatter/unibeautify.ts
@@ -1,0 +1,238 @@
+import { ExtensionContext, OutputChannel, Range, TextDocument, Uri, workspace } from 'coc.nvim';
+
+import fs from 'fs';
+import path from 'path';
+import unibeautify, { BeautifyData, OptionValues } from 'unibeautify';
+import yaml from 'js-yaml';
+
+import { Beautifier } from 'unibeautify';
+import prettyDiff from '@unibeautify/beautifier-prettydiff';
+import jsBeautify from '@unibeautify/beautifier-js-beautify';
+
+const beautifiers: Beautifier[] = [jsBeautify, prettyDiff];
+
+export async function doUnibeautifyFormat(
+  context: ExtensionContext,
+  outputChannel: OutputChannel,
+  document: TextDocument,
+  range?: Range
+): Promise<string> {
+  const extensionConfig = workspace.getConfiguration('htmldjango');
+
+  const fileName = Uri.parse(document.uri).fsPath;
+  const text = document.getText(range);
+
+  let htmlLanguageOptions: OptionValues;
+
+  const configFile = existsConfigFile();
+  if (configFile.exists) {
+    htmlLanguageOptions = loadConfigFile(configFile.filePath, configFile.fileType);
+  } else {
+    htmlLanguageOptions = {
+      brace_style: extensionConfig.get('unibeautify.brace_style'),
+      end_with_newline: extensionConfig.get('unibeautify.end_with_newline'),
+      force_indentation: extensionConfig.get('unibeautify.force_indentation'),
+      indent_comments: extensionConfig.get('unibeautify.indent_comments'),
+      indent_inner_html: extensionConfig.get('unibeautify.indent_inner_html'),
+      indent_scripts: extensionConfig.get('unibeautify.indent_scripts'),
+      indent_size: extensionConfig.get('unibeautify.indent_size'),
+      indent_style: extensionConfig.get('unibeautify.indent_style'),
+      max_preserve_newlines: extensionConfig.get('unibeautify.max_preserve_newlines'),
+      newline_before_tags: extensionConfig.get('unibeautify.newline_before_tags'),
+      preserve_newlines: extensionConfig.get('unibeautify.preserve_newlines'),
+      quotes: extensionConfig.get('unibeautify.quotes'),
+      unformatted: extensionConfig.get('unibeautify.unformatted'),
+      wrap_attributes: extensionConfig.get('unibeautify.wrap_attributes'),
+      wrap_attributes_indent_size: extensionConfig.get('unibeautify.wrap_attributes_indent_size'),
+      wrap_line_length: extensionConfig.get('unibeautify.wrap_line_length'),
+    };
+  }
+
+  unibeautify.loadBeautifiers(beautifiers);
+
+  const beautifyData: BeautifyData = {
+    text,
+    filePath: fileName,
+    projectPath: workspace.root,
+    options: {
+      // https://unibeautify.com/docs/language-html
+      ['HTML']: htmlLanguageOptions,
+    },
+    languageName: 'HTML',
+    fileExtension: '.html',
+  };
+
+  outputChannel.appendLine(`${'#'.repeat(10)} unibeautify\n`);
+  outputChannel.appendLine(`File: ${fileName}`);
+
+  return safeExecution(
+    () => {
+      return unibeautify.beautify(beautifyData);
+    },
+    text,
+    fileName,
+    outputChannel
+  );
+}
+
+function safeExecution(
+  //cb: (() => string) | Promise<string>,
+  cb: () => Promise<string>,
+  defaultText: string,
+  fileName: string,
+  outputChannel: OutputChannel
+): string | Promise<string> {
+  if (cb instanceof Promise) {
+    return cb
+      .then((returnValue) => {
+        return returnValue;
+      })
+      .catch((err: Error) => {
+        outputChannel.appendLine(`\n==== ERR ===\n`);
+        outputChannel.appendLine(`${err}`);
+        // eslint-disable-next-line no-console
+        console.error(fileName, err);
+        return defaultText;
+      });
+  }
+
+  try {
+    outputChannel.appendLine(''); // dummy
+    return cb();
+  } catch (err) {
+    outputChannel.appendLine(`\n==== ERR ===\n`);
+    outputChannel.appendLine(`${err}`);
+    // eslint-disable-next-line no-console
+    console.error(fileName, err);
+    return defaultText;
+  }
+}
+
+interface ExistsConfigFile {
+  exists: boolean;
+  filePath: string;
+  fileType: 'yaml' | 'json' | 'none';
+}
+
+function existsConfigFile(): ExistsConfigFile {
+  const r: ExistsConfigFile = {
+    exists: false,
+    filePath: '',
+    fileType: 'none',
+  };
+
+  const workspaceRootDir = Uri.file(workspace.root).fsPath;
+  if (fs.existsSync(path.join(workspaceRootDir, '.unibeautifyrc.yml'))) {
+    r.exists = true;
+    r.filePath = path.join(workspaceRootDir, '.unibeautifyrc.yml');
+    r.fileType = 'yaml';
+  } else if (fs.existsSync(path.join(workspaceRootDir, '.unibeautifyrc.yaml'))) {
+    r.exists = true;
+    r.filePath = path.join(workspaceRootDir, '.unibeautifyrc.yaml');
+    r.fileType = 'yaml';
+  } else if (fs.existsSync(path.join(workspaceRootDir, '.unibeautifyrc.json'))) {
+    r.exists = true;
+    r.filePath = path.join(workspaceRootDir, '.unibeautifyrc.json');
+    r.fileType = 'json';
+  }
+
+  return r;
+}
+
+function loadConfigFile(filePath: string, fileType: 'yaml' | 'json' | 'none'): OptionValues {
+  let options: OptionValues = {};
+
+  if (!fs.existsSync(filePath) || fileType === 'none') {
+    return options;
+  }
+
+  if (fileType === 'yaml') {
+    try {
+      const configData = yaml.load(fs.readFileSync(filePath, 'utf8'));
+
+      if (configData && typeof configData === 'object') {
+        options = parseConfigData(configData['HTML']);
+      }
+    } catch (e) {
+      return options;
+    }
+  }
+
+  if (fileType === 'json') {
+    try {
+      const configData = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+
+      if (configData && typeof configData === 'object') {
+        options = parseConfigData(configData['HTML']);
+      }
+    } catch (e) {
+      return options;
+    }
+  }
+
+  return options;
+}
+
+function parseConfigData(dataObj: any): OptionValues {
+  // Exclude settings that are not supported by "JS-Beautify, Pretty Diff" from the parse.
+  // https://unibeautify.com/docs/language-html
+  const optionKeyList = [
+    //'align_assignments',
+    //'arrow_parens',
+    'brace_style',
+    //'break_chained_methods',
+    //'comma_first',
+    //'end_of_line',
+    //'end_with_comma',
+    'end_with_newline',
+    //'end_with_semicolon',
+    'force_indentation',
+    //'identifier_case',
+    //'indent_chained_methods',
+    //'indent_char',
+    'indent_comments',
+    'indent_inner_html',
+    //'indent_level',
+    'indent_scripts',
+    'indent_size',
+    'indent_style',
+    //'indent_with_tabs',
+    //'jslint_happy',
+    //'jsx_brackets',
+    //'keep_array_indentation',
+    //'keyword_case',
+    'max_preserve_newlines',
+    //'multiline_ternary',
+    'newline_before_tags',
+    //'newline_between_rules',
+    //'no_leading_zero',
+    //'object_curly_spacing',
+    //'pragma_insert',
+    //'pragma_require',
+    'preserve_newlines',
+    'quotes',
+    //'remove_trailing_whitespace',
+    //'selector_separator_newline',
+    //'space_after_anon_function',
+    //'space_before_conditional',
+    //'space_in_empty_paren',
+    //'space_in_paren',
+    //'typesafe_equality_operators',
+    //'unescape_strings',
+    'unformatted',
+    //'unindent_chained_methods',
+    'wrap_attributes',
+    'wrap_attributes_indent_size',
+    'wrap_line_length',
+    //'wrap_prose',
+  ];
+
+  const options: OptionValues = {};
+  for (const item of optionKeyList) {
+    if (item in dataObj) {
+      options[item] = dataObj[item];
+    }
+  }
+
+  return options;
+}

--- a/src/hover.ts
+++ b/src/hover.ts
@@ -20,7 +20,6 @@ export class HtmlDjangoHoverProvider implements HoverProvider {
     const doc = workspace.getDocument(document.uri);
     if (!doc) return null;
 
-    //const wordRange = doc.getWordRangeAtPosition(position, '@');
     const wordRange = doc.getWordRangeAtPosition(position);
     if (!wordRange) return null;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,22 @@
-import { commands, Disposable, DocumentSelector, ExtensionContext, languages, TextEdit, workspace } from 'coc.nvim';
+import {
+  commands,
+  Disposable,
+  DocumentSelector,
+  ExtensionContext,
+  languages,
+  TextEdit,
+  window,
+  workspace,
+  WorkspaceConfiguration,
+} from 'coc.nvim';
 
-import HtmlDjangoFormattingEditProvider, { doFormat, fullDocumentRange } from './format';
+import fs from 'fs';
+import which from 'which';
 
+import HtmlDjangoFormattingEditProvider, { fullDocumentRange } from './format';
 import { HtmlDjangoHoverProvider } from './hover';
+import { djhtmlInstall } from './installer';
+import { resolveDjhtmlPath } from './tool';
 
 interface Selectors {
   rangeLanguageSelector: DocumentSelector;
@@ -12,9 +26,6 @@ interface Selectors {
 let formatterHandler: undefined | Disposable;
 let rangeFormatterHandler: undefined | Disposable;
 
-/**
- * Dispose formatters
- */
 function disposeHandlers(): void {
   if (formatterHandler) {
     formatterHandler.dispose();
@@ -26,9 +37,6 @@ function disposeHandlers(): void {
   rangeFormatterHandler = undefined;
 }
 
-/**
- * Build formatter selectors
- */
 function selectors(): Selectors {
   const languageSelector = [{ language: 'htmldjango', scheme: 'file' }];
   const rangeLanguageSelector = [{ language: 'htmldjango', scheme: 'file' }];
@@ -45,27 +53,73 @@ export async function activate(context: ExtensionContext): Promise<void> {
   const isEnable = extensionConfig.get<boolean>('enable', true);
   if (!isEnable) return;
 
-  const priority = 1;
-  const editProvider = new HtmlDjangoFormattingEditProvider();
-
-  function registerFormatter(): void {
-    disposeHandlers();
-    const { languageSelector, rangeLanguageSelector } = selectors();
-
-    rangeFormatterHandler = languages.registerDocumentRangeFormatProvider(
-      rangeLanguageSelector,
-      editProvider,
-      priority
-    );
-    formatterHandler = languages.registerDocumentFormatProvider(languageSelector, editProvider, priority);
+  const extensionStoragePath = context.storagePath;
+  if (!fs.existsSync(extensionStoragePath)) {
+    fs.mkdirSync(extensionStoragePath);
   }
-  registerFormatter();
+
+  const outputChannel = window.createOutputChannel('htmldjango');
+
+  const isRealpath = true;
+  const pythonCommand = getPythonPath(extensionConfig, isRealpath);
 
   subscriptions.push(
-    commands.registerCommand('htmldjango.Format', async () => {
-      const doc = await workspace.document;
+    commands.registerCommand('htmldjango.djhtml.install', async () => {
+      await installWrapper(pythonCommand, context);
+    })
+  );
 
-      const code = await doFormat(doc.textDocument, undefined);
+  // **TODO**:
+  // Default: unibeautify
+  // Plan to change to djhtml in the future.
+  const formattingProvider = extensionConfig.get<string>('formatting.provider', 'unibeautify');
+
+  let djhtmlPath = extensionConfig.get('djhtml.commandPath', '');
+  djhtmlPath = resolveDjhtmlPath(context, djhtmlPath);
+
+  if (formattingProvider === 'djhtml') {
+    if (!djhtmlPath) {
+      if (pythonCommand) {
+        await installWrapper(pythonCommand, context);
+      }
+    }
+  }
+
+  const editProvider = new HtmlDjangoFormattingEditProvider(context, outputChannel);
+  const priority = 1;
+
+  if (formattingProvider === 'unibeautify' || formattingProvider === 'djhtml') {
+    function registerFormatter(): void {
+      disposeHandlers();
+      const { languageSelector, rangeLanguageSelector } = selectors();
+
+      rangeFormatterHandler = languages.registerDocumentRangeFormatProvider(
+        rangeLanguageSelector,
+        editProvider,
+        priority
+      );
+      formatterHandler = languages.registerDocumentFormatProvider(languageSelector, editProvider, priority);
+    }
+    registerFormatter();
+  }
+
+  subscriptions.push(
+    commands.registerCommand('htmldjango.unibeautify.format', async () => {
+      const doc = await workspace.document;
+      const doFormat = editProvider.getFormatFunc('unibeautify');
+      const code = await doFormat(context, outputChannel, doc.textDocument, undefined);
+      const edits = [TextEdit.replace(fullDocumentRange(doc.textDocument), code)];
+      if (edits) {
+        await doc.applyEdits(edits);
+      }
+    })
+  );
+
+  subscriptions.push(
+    commands.registerCommand('htmldjango.djhtml.format', async () => {
+      const doc = await workspace.document;
+      const doFormat = editProvider.getFormatFunc('djhtml');
+      const code = await doFormat(context, outputChannel, doc.textDocument, undefined);
       const edits = [TextEdit.replace(fullDocumentRange(doc.textDocument), code)];
       if (edits) {
         await doc.applyEdits(edits);
@@ -74,4 +128,50 @@ export async function activate(context: ExtensionContext): Promise<void> {
   );
 
   context.subscriptions.push(languages.registerHoverProvider(['htmldjango'], new HtmlDjangoHoverProvider(context)));
+}
+
+async function installWrapper(pythonCommand: string, context: ExtensionContext) {
+  const msg = 'Install/Upgrade "djhtml"?';
+  context.workspaceState;
+
+  let ret = 0;
+  ret = await window.showQuickpick(['Yes', 'Cancel'], msg);
+  if (ret === 0) {
+    try {
+      await djhtmlInstall(pythonCommand, context);
+    } catch (e) {
+      return;
+    }
+  } else {
+    return;
+  }
+}
+
+function getPythonPath(config: WorkspaceConfiguration, isRealpath?: boolean): string {
+  let pythonPath = config.get<string>('builtin.pythonPath', '');
+  if (pythonPath) {
+    return pythonPath;
+  }
+
+  try {
+    pythonPath = which.sync('python3');
+    if (isRealpath) {
+      pythonPath = fs.realpathSync(pythonPath);
+    }
+    return pythonPath;
+  } catch (e) {
+    // noop
+  }
+
+  try {
+    pythonPath = which.sync('python');
+    if (isRealpath) {
+      pythonPath = fs.realpathSync(pythonPath);
+    }
+    return pythonPath;
+  } catch (e) {
+    // noop
+  }
+
+  return pythonPath;
 }

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -1,0 +1,39 @@
+import { ExtensionContext, window } from 'coc.nvim';
+
+import path from 'path';
+
+import rimraf from 'rimraf';
+import child_process from 'child_process';
+import util from 'util';
+
+import { DJHTML_VERSION } from './constant';
+
+const exec = util.promisify(child_process.exec);
+
+export async function djhtmlInstall(pythonCommand: string, context: ExtensionContext): Promise<void> {
+  const pathVenv = path.join(context.storagePath, 'djhtml', 'venv');
+
+  let pathVenvPython = path.join(context.storagePath, 'djhtml', 'venv', 'bin', 'python');
+  if (process.platform === 'win32') {
+    pathVenvPython = path.join(context.storagePath, 'djhtml', 'venv', 'Scripts', 'python');
+  }
+
+  const statusItem = window.createStatusBarItem(0, { progress: true });
+  statusItem.text = `Install djhtml...`;
+  statusItem.show();
+
+  const installCmd =
+    `${pythonCommand} -m venv ${pathVenv} && ` + `${pathVenvPython} -m pip install -U pip djhtml==${DJHTML_VERSION}`;
+
+  rimraf.sync(pathVenv);
+  try {
+    window.showMessage(`Install djhtml...`);
+    await exec(installCmd);
+    statusItem.hide();
+    window.showMessage(`djhtml: installed!`);
+  } catch (error) {
+    statusItem.hide();
+    window.showErrorMessage(`djhtml: install failed. | ${error}`);
+    throw new Error();
+  }
+}

--- a/src/tool.ts
+++ b/src/tool.ts
@@ -1,0 +1,36 @@
+import { ExtensionContext } from 'coc.nvim';
+
+import fs from 'fs';
+import path from 'path';
+
+import which from 'which';
+
+export function whichCmd(cmd: string): string {
+  try {
+    return which.sync(cmd);
+  } catch (error) {
+    return '';
+  }
+}
+
+export function resolveDjhtmlPath(context: ExtensionContext, toolPath: string): string {
+  if (!toolPath) {
+    const whichDjhtml = whichCmd('djhtml');
+    if (whichDjhtml) {
+      toolPath = whichDjhtml;
+    } else if (
+      fs.existsSync(path.join(context.storagePath, 'djhtml', 'venv', 'Scripts', 'djhtml.exe')) ||
+      fs.existsSync(path.join(context.storagePath, 'djhtml', 'venv', 'bin', 'djhtml'))
+    ) {
+      if (process.platform === 'win32') {
+        toolPath = path.join(context.storagePath, 'djhtml', 'venv', 'Scripts', 'djhtml.exe');
+      } else {
+        toolPath = path.join(context.storagePath, 'djhtml', 'venv', 'bin', 'djhtml');
+      }
+    } else {
+      toolPath = '';
+    }
+  }
+
+  return toolPath;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -59,6 +59,14 @@
     "@nodelib/fs.scandir" "2.1.4"
     fastq "^1.6.0"
 
+"@types/glob@*":
+  version "7.1.3"
+  resolved "https://registry.yarnpkg.com/@types/glob/-/glob-7.1.3.tgz#e6ba80f36b7daad2c685acd9266382e68985c183"
+  integrity sha512-SEYeGAIQIQX8NN6LDKprLjbrd5dARM5EXsd8GI/A5l0apYI1fGMWgPHSe4ZKL4eozlAyI+doUE9XbYS4xCkQ1w==
+  dependencies:
+    "@types/minimatch" "*"
+    "@types/node" "*"
+
 "@types/js-yaml@^4.0.0":
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/@types/js-yaml/-/js-yaml-4.0.1.tgz#5544730b65a480b18ace6b6ce914e519cec2d43b"
@@ -69,10 +77,38 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.7.tgz#98a993516c859eb0d5c4c8f098317a9ea68db9ad"
   integrity sha512-cxWFQVseBm6O9Gbw1IWb8r6OS4OhSt3hPZLkFApLjM8TEXROBuQGLAH2i2gZpcXdLBIrpXuTDhH7Vbm1iXmNGA==
 
+"@types/minimatch@*":
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.4.tgz#f0ec25dbf2f0e4b18647313ac031134ca5b24b21"
+  integrity sha512-1z8k4wzFnNjVK/tlxvrWuK5WMt6mydWWP7+zvH5eFep4oj+UkrfiJTRtjCeBXNpwaA/FYqqtb4/QS4ianFpIRA==
+
+"@types/node@*":
+  version "15.12.0"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-15.12.0.tgz#6a459d261450a300e6865faeddb5af01c3389bb3"
+  integrity sha512-+aHJvoCsVhO2ZCuT4o5JtcPrCPyDE3+1nvbDprYes+pPkEsbjH7AGUCNtjMOXS0fqH14t+B7yLzaqSz92FPWyw==
+
 "@types/node@^14.6.3":
   version "14.14.41"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.41.tgz#d0b939d94c1d7bd53d04824af45f1139b8c45615"
   integrity sha512-dueRKfaJL4RTtSa7bWeTK1M+VH+Gns73oCgzvYfHZywRCoPSd8EkXBL0mZ9unPTveBn+D9phZBaxuzpwjWkW0g==
+
+"@types/rimraf@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@types/rimraf/-/rimraf-3.0.0.tgz#b9d03f090ece263671898d57bb7bb007023ac19f"
+  integrity sha512-7WhJ0MdpFgYQPXlF4Dx+DhgvlPCfz/x5mHaeDQAKhcenvQP1KCpLQ18JklAqeGMYSAT2PxLpzd0g2/HE7fj7hQ==
+  dependencies:
+    "@types/glob" "*"
+    "@types/node" "*"
+
+"@types/tmp@^0.2.0":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@types/tmp/-/tmp-0.2.0.tgz#e3f52b4d7397eaa9193592ef3fdd44dc0af4298c"
+  integrity sha512-flgpHJjntpBAdJD43ShRosQvNC0ME97DCfGvZEDlAThQmnerRXrLbX6YgzRBQCZTthET9eAWFAMaYP0m0Y4HzQ==
+
+"@types/which@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@types/which/-/which-2.0.0.tgz#446d35586611dee657120de8e0457382a658fc25"
+  integrity sha512-JHTNOEpZnACQdsTojWggn+SQ8IucfqEhtz7g8Z0G67WdSj4x3F0X5I2c/CVcl8z/QukGrIHeQ/N49v1au74XFQ==
 
 "@typescript-eslint/eslint-plugin@^4.8.2":
   version "4.22.0"
@@ -307,11 +343,6 @@ color-convert@^2.0.1:
   integrity sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==
   dependencies:
     color-name "~1.1.4"
-
-color-name@1.1.3:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
-  integrity sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=
 
 color-name@~1.1.4:
   version "1.1.4"
@@ -1180,6 +1211,13 @@ reusify@^1.0.4:
   resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.0.4.tgz#90da382b1e126efc02146e90845a88db12925d76"
   integrity sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==
 
+rimraf@^2.6.3:
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.7.1.tgz#35797f13a7fdadc566142c29d4f07ccad483e3ec"
+  integrity sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==
+  dependencies:
+    glob "^7.1.3"
+
 rimraf@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
@@ -1349,6 +1387,13 @@ text-table@^0.2.0:
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
   integrity sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=
 
+tmp@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.1.0.tgz#ee434a4e22543082e294ba6201dcc6eafefa2877"
+  integrity sha512-J7Z2K08jbGcdA1kkQpJSqLF6T0tdQqpR2pnSUXsIchbPdTI9v3e85cLW0d6WDhwuAleOV71j2xWs8qMPfK7nKw==
+  dependencies:
+    rimraf "^2.6.3"
+
 to-regex-range@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/to-regex-range/-/to-regex-range-5.0.1.tgz#1648c44aae7c8d988a326018ed72f5b4dd0392e4"
@@ -1432,7 +1477,7 @@ validate-npm-package-license@^3.0.1:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
 
-which@^2.0.1:
+which@^2.0.1, which@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/which/-/which-2.0.2.tgz#7c6a8dd0a636a0327e10b59c9286eee93f3f51b1"
   integrity sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==


### PR DESCRIPTION
## DEMO

![coc-htmldjango-djhtml](https://user-images.githubusercontent.com/188642/120850016-d77b5700-c5b1-11eb-8b21-a636de63f4c7.gif)

## Description

- Tool
  - [rtts/djhtml](https://github.com/rtts/djhtml) for python
    - Django/Jinja template indenter

### Add configurations

- `htmldjango.builtin.pythonPath`
- `htmldjango.formatting.provider`
- `htmldjango.djhtml.commandPath`
- `htmldjango.djhtml.tabWidth`

### Add commands

- `htmldjango.djhtml.install`
- `htmldjango.djhtml.format`
- `htmldjango.unibeautify.format`

### Remove commands

- `htmldjango.Format`

## Thanks

@luisiacc, Thanks for sharing this tool with me.
