### PR TITLE
feat: "djLint" integration (linter, formatter)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,24 +8,15 @@ django templates (htmldjango) extension for [coc.nvim](https://github.com/neocli
 
 - Format
   - by [DjHTML](https://github.com/rtts/djhtml) ("Django/Jinja" template indenter) | [DEMO](https://github.com/yaegassy/coc-htmldjango/pull/2)
+  - [Experimental] by [djLint](https://github.com/Riverside-Healthcare/djlint) (reformat HTML templates)
+- [Experimental] Lint (default: `false`)
+  - by [djLint](https://github.com/Riverside-Healthcare/djlint) (Find common formatting issues)
 - Hover | [DEMO](https://github.com/yaegassy/coc-htmldjango/pull/1)
 - CodeAction | [DEMO](https://github.com/yaegassy/coc-htmldjango/pull/3)
 - Snippets completion
   - To use it, you need to install [coc-snippets](https://github.com/neoclide/coc-snippets).
   - And set `snippets.loadFromExtensions` to true in "coc-settings.json"
-- Built-in installer (DjHTML)
-
-It is possible to use `coc-htmldjango` with filetype other than `htmldjango`.
-
-Set `g:coc_filetype_map` in ".vimrc" or "init.vim".
-
-**e.g. jinja html**:
-
-```vim
-let g:coc_filetype_map = {
-  \ 'jinja.html': 'htmldjango',
-  \ }
-```
+- Built-in installer (DjHTML, djLint)
 
 ## Install
 
@@ -41,17 +32,29 @@ let g:coc_filetype_map = {
 Plug 'yaegassy/coc-htmldjango', {'do': 'yarn install --frozen-lockfile'}
 ```
 
+**Recommended coc extension**:
+
+- [coc-html](https://github.com/neoclide/coc-html)
+- [coc-snippets](https://github.com/neoclide/coc-snippets).
+
 ## Configuration options for coc-htmldjango
 
 - `htmldjango.enable`: Enable coc-htmldjango extension, default: `true`
 - `htmldjango.builtin.pythonPath`: Python 3.x path (Absolute path) to be used for built-in install, default: `""`
+- `htmldjango.formatting.provider`: Provider for formatting. Possible options include 'djhtml', 'djlint', and 'none', default: `"djhtml"`
 - `htmldjango.djhtml.commandPath`: The custom path to the djhtml (Absolute path), default: `""`
 - `htmldjango.djhtml.tabWidth`: Set tabwidth (--tabwidth), default: `4`
+- `htmldjango.djlint.commandPath`: The custom path to the djlint (Absolute path), default: `""`
+- `htmldjango.djlint.enable`: Enable djLint (diagnostics), default: `false`
+- `htmldjango.djlint.lintOnOpen`: Lint file on opening, default: `true`
+- `htmldjango.djlint.lintOnChange`: Lint file on change, default: `true`
+- `htmldjango.djlint.lintOnSave`: Lint file on save, default: `true`
 
 ## Commands
 
 - `htmldjango.builtin.installTools`
 - `htmldjango.djhtml.format`
+- `htmldjango.djlint.format`
 
 ## Code Actions
 
@@ -78,6 +81,7 @@ coc-htmldjango allows you to create an extension-only "venv" and install "djhtml
 
 - [vscode-django/vscode-django](https://github.com/vscode-django/vscode-django)
 - [rtts/djhtml](https://github.com/rtts/djhtml)
+- [Riverside-Healthcare/djlint](https://github.com/Riverside-Healthcare/djlint)
 - [Unibeautify/unibeautify](https://github.com/Unibeautify/unibeautify)
 - [neoclide/coc-snippets](https://github.com/neoclide/coc-snippets)
 - [neoclide/coc-html](https://github.com/neoclide/coc-html)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "coc-htmldjango",
   "version": "0.5.2",
+  "djlintVersion": "0.4.0",
   "djhtmlVersion": "1.4.9",
   "description": "django templates (htmldjango) extension for coc.nvim. Provides formatter, snippets completion and more...",
   "author": "yaegassy <yosstools@gmail.com>",
@@ -61,6 +62,14 @@
     "onLanguage:htmldjango"
   ],
   "contributes": {
+    "rootPatterns": [
+      {
+        "filetype": "htmldjango",
+        "patterns": [
+          "pyproject.toml"
+        ]
+      }
+    ],
     "configuration": {
       "type": "object",
       "title": "coc-htmldjango configuration",
@@ -87,9 +96,10 @@
         "htmldjango.formatting.provider": {
           "type": "string",
           "default": "djhtml",
-          "description": "Provider for formatting. Possible options include 'djhtml' and 'unibeautify'",
+          "description": "Provider for formatting. Possible options include 'djhtml' and 'djlint'",
           "enum": [
             "djhtml",
+            "djlint",
             "unibeautify",
             "none"
           ]
@@ -103,6 +113,31 @@
           "type": "number",
           "default": 4,
           "description": "Set tabwidth (--tabwidth)"
+        },
+        "htmldjango.djlint.commandPath": {
+          "type": "string",
+          "default": "",
+          "description": "The custom path to the djlint (Absolute path)."
+        },
+        "htmldjango.djlint.enableLint": {
+          "type": "boolean",
+          "default": false,
+          "description": "Enable djLint lint (diagnostics)"
+        },
+        "htmldjango.djlint.lintOnOpen": {
+          "type": "boolean",
+          "default": true,
+          "description": "Lint file on opening"
+        },
+        "htmldjango.djlint.lintOnChange": {
+          "type": "boolean",
+          "default": true,
+          "description": "Lint file on change"
+        },
+        "htmldjango.djlint.lintOnSave": {
+          "type": "boolean",
+          "default": true,
+          "description": "Lint file on save"
         },
         "htmldjango.unibeautify.brace_style": {
           "type": "string",
@@ -291,6 +326,10 @@
       {
         "command": "htmldjango.djhtml.format",
         "title": "DjHTML format"
+      },
+      {
+        "command": "htmldjango.djlint.format",
+        "title": "djLint format"
       }
     ],
     "snippets": [

--- a/src/constant.ts
+++ b/src/constant.ts
@@ -5,8 +5,11 @@
  */
 
 // @ts-ignore
+import { djlintVersion } from '../package.json';
+// @ts-ignore
 import { djhtmlVersion } from '../package.json';
 
 export const SUPPORT_LANGUAGES = ['htmldjango'];
 
 export const DJHTML_VERSION = djhtmlVersion;
+export const DJLINT_VERSION = djlintVersion;

--- a/src/format.ts
+++ b/src/format.ts
@@ -9,6 +9,7 @@ import {
 } from 'coc.nvim';
 
 import { doDjhtmlFormat } from './formatter/djhtml';
+import { doDjlintFormat } from './formatter/djlint';
 import { doUnibeautifyFormat } from './formatter/unibeautify';
 
 export type FormatFuncType = (
@@ -52,6 +53,8 @@ class HtmlDjangoFormattingEditProvider implements DocumentFormattingEditProvider
         formatterFunc = doUnibeautifyFormat;
       } else if (formatter === 'djhtml') {
         formatterFunc = doDjhtmlFormat;
+      } else if (formatter === 'djlint') {
+        formatterFunc = doDjlintFormat;
       }
     } else {
       const extensionConfig = workspace.getConfiguration('htmldjango');
@@ -61,6 +64,8 @@ class HtmlDjangoFormattingEditProvider implements DocumentFormattingEditProvider
         formatterFunc = doUnibeautifyFormat;
       } else if (formattingProvider === 'djhtml') {
         formatterFunc = doDjhtmlFormat;
+      } else if (formattingProvider === 'djlint') {
+        formatterFunc = doDjlintFormat;
       }
     }
 

--- a/src/formatter/djlint.ts
+++ b/src/formatter/djlint.ts
@@ -1,0 +1,99 @@
+import { ExtensionContext, OutputChannel, Range, TextDocument, Uri, workspace, window } from 'coc.nvim';
+
+import cp from 'child_process';
+import fs from 'fs';
+import tmp from 'tmp';
+
+import { SUPPORT_LANGUAGES } from '../constant';
+import { resolveDjlintPath } from '../tool';
+
+export async function doDjlintFormat(
+  context: ExtensionContext,
+  outputChannel: OutputChannel,
+  document: TextDocument,
+  range?: Range
+): Promise<string> {
+  if (!SUPPORT_LANGUAGES.includes(document.languageId)) {
+    throw '"djlint" cannot run, not supported language';
+  }
+
+  const extensionConfig = workspace.getConfiguration('htmldjango');
+
+  const text = document.getText(range);
+  const fileName = Uri.parse(document.uri).fsPath;
+
+  let djlintPath = extensionConfig.get('djlint.commandPath', '');
+  djlintPath = resolveDjlintPath(context, djlintPath);
+  if (!djlintPath) {
+    window.showErrorMessage('Unable to find the "djlint" command.');
+    return text;
+  }
+
+  const args: string[] = [];
+  const cwd = Uri.file(workspace.root).fsPath;
+  // Use shell
+  const opts = { cwd, shell: true };
+
+  args.push('--reformat');
+
+  const tmpFile = tmp.fileSync();
+  fs.writeFileSync(tmpFile.name, text);
+
+  // ---- Output the command to be executed to channel log. ----
+  outputChannel.appendLine(`${'#'.repeat(10)} djlint (format)\n`);
+  outputChannel.appendLine(`Cwd: ${opts.cwd}`);
+  outputChannel.appendLine(`File: ${fileName}`);
+  outputChannel.appendLine(`Args: ${args.join(' ')}`);
+  outputChannel.appendLine(`Run: ${djlintPath} ${args.join(' ')} ${tmpFile.name}`);
+
+  return new Promise(function (resolve) {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    cp.execFile(djlintPath, [...args, tmpFile.name], opts, function (error, stdout, stderr) {
+      let updateText: string;
+      const originalText = fs.readFileSync(tmpFile.name, 'utf-8');
+
+      if (error) {
+        if (error.code === 2 || error.code === 127) {
+          outputChannel.appendLine(`\n==== ${JSON.stringify(error)} ===\n`);
+          throw error;
+        }
+      }
+
+      if (stdout) {
+        outputChannel.appendLine(`\n==== STDOUT ===\n`);
+        outputChannel.appendLine(`${stdout}`);
+
+        const isSuccess = isSuccessFormat(stdout);
+        outputChannel.appendLine(`== success ==: ${isSuccess}\n`);
+        if (isSuccess) {
+          updateText = fs.readFileSync(tmpFile.name, 'utf-8');
+        } else {
+          updateText = originalText;
+        }
+      } else {
+        updateText = originalText;
+        outputChannel.appendLine('');
+      }
+
+      tmpFile.removeCallback();
+      resolve(updateText);
+    });
+  });
+}
+
+function isSuccessFormat(s: string) {
+  let flag = false;
+  const lines = s.split('\n');
+  const p = /^(?<num>\d+)\sfile was updated.$/;
+
+  for (const v of lines) {
+    const m = v.match(p);
+    if (m) {
+      if (Number(m.groups?.num) >= 1) {
+        flag = true;
+      }
+    }
+  }
+
+  return flag;
+}

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -6,7 +6,7 @@ import rimraf from 'rimraf';
 import child_process from 'child_process';
 import util from 'util';
 
-import { DJHTML_VERSION } from './constant';
+import { DJHTML_VERSION, DJLINT_VERSION } from './constant';
 
 const exec = util.promisify(child_process.exec);
 
@@ -23,7 +23,8 @@ export async function installTools(pythonCommand: string, context: ExtensionCont
   statusItem.show();
 
   const installCmd =
-    `${pythonCommand} -m venv ${pathVenv} && ` + `${pathVenvPython} -m pip install -U pip djhtml==${DJHTML_VERSION}`;
+    `${pythonCommand} -m venv ${pathVenv} && ` +
+    `${pathVenvPython} -m pip install -U pip djhtml==${DJHTML_VERSION} djlint==${DJLINT_VERSION}`;
 
   rimraf.sync(pathVenv);
   try {

--- a/src/lint.ts
+++ b/src/lint.ts
@@ -1,0 +1,194 @@
+import {
+  Diagnostic,
+  DiagnosticCollection,
+  DiagnosticSeverity,
+  languages,
+  OutputChannel,
+  Position,
+  Range,
+  TextDocument,
+  Uri,
+  workspace,
+} from 'coc.nvim';
+
+import cp from 'child_process';
+
+import { SUPPORT_LANGUAGES } from './constant';
+
+interface DjlintDiagnostics {
+  ruleName: string;
+  line: number;
+  col: number;
+  message: string;
+}
+
+export class LintEngine {
+  private collection: DiagnosticCollection;
+  private cmdPath: string;
+  private outputChannel: OutputChannel;
+
+  constructor(cmdPath: string, outputChannel: OutputChannel) {
+    this.collection = languages.createDiagnosticCollection('djlint');
+    this.cmdPath = cmdPath;
+    this.outputChannel = outputChannel;
+  }
+
+  public async lint(textDocument: TextDocument): Promise<void> {
+    if (!SUPPORT_LANGUAGES.includes(textDocument.languageId)) return;
+
+    // eslint-disable-next-line @typescript-eslint/no-this-alias
+    const self = this;
+    const filePath = Uri.parse(textDocument.uri).fsPath;
+    const args: string[] = [];
+    const cwd = Uri.file(workspace.root).fsPath;
+    const opts = { cwd, shell: true };
+    args.push('-');
+
+    this.outputChannel.appendLine(`${'#'.repeat(10)} djlint (lint)\n`);
+    this.outputChannel.appendLine(`Cwd: ${opts.cwd}`);
+    this.outputChannel.appendLine(`File: ${filePath}`);
+    this.outputChannel.appendLine(`Args: ${args.join(' ')}`);
+    this.outputChannel.appendLine(`Run: ${self.cmdPath} ${args.join(' ')}`);
+
+    this.collection.clear();
+
+    return new Promise(function (resolve) {
+      const cps = cp.spawn(self.cmdPath, args, opts);
+      cps.stdin.write(textDocument.getText());
+      cps.stdin.end();
+
+      let buffer = '';
+      const onDataEvent = (data: Buffer) => {
+        buffer += data.toString();
+      };
+
+      let djlintDiagnostics: DjlintDiagnostics[];
+      const onEndEvent = () => {
+        self.outputChannel.appendLine(`\n==== STDOUT ===\n`);
+        self.outputChannel.appendLine(`${buffer}`);
+
+        try {
+          djlintDiagnostics = self.parseRegex(buffer);
+        } catch (error) {
+          self.outputChannel.appendLine(`\n==== Error ===\n`);
+          self.outputChannel.appendLine(`Failed: parse failure`);
+          return;
+        }
+
+        const diagnostics: Diagnostic[] = [];
+
+        if (djlintDiagnostics && djlintDiagnostics.length > 0) {
+          for (const d of djlintDiagnostics) {
+            // MEMO: col is adjusted because it may return 0
+            const startLine = d.line !== 0 ? d.line - 1 : d.line;
+            const startCharacter = d.col !== 0 ? d.col - 1 : d.col;
+            const endLine = startLine;
+            const endCharacter = startCharacter;
+
+            const startPosition = Position.create(startLine, startCharacter);
+            const endPosition = Position.create(endLine, endCharacter);
+
+            const severity = self.getSeverity(d.ruleName);
+
+            diagnostics.push({
+              range: Range.create(startPosition, endPosition),
+              message: d.message,
+              severity,
+              source: 'djlint',
+              code: d.ruleName,
+              relatedInformation: [],
+            });
+          }
+
+          self.collection.set(textDocument.uri, diagnostics);
+        } else {
+          // MEMO: Dealing with cases where the diagnosis is 0 but the signature remains.
+          self.collection.set(textDocument.uri, null);
+        }
+
+        resolve();
+      };
+
+      // If there is an stderr
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      cps.stderr.on('data', (error) => {
+        // MEMO: debug
+        //self.outputChannel.appendLine(`\n==== STDERR ====\n`);
+        //self.outputChannel.appendLine(`${stripAnsi(String(error))}`);
+        //self.outputChannel.appendLine(`\n==== /STDERR ====\n`);
+      });
+
+      cps.stdout.on('data', onDataEvent);
+      cps.stdout.on('end', onEndEvent);
+
+      resolve();
+    });
+  }
+
+  public parseRegex(s: string): DjlintDiagnostics[] {
+    const diagnostics: DjlintDiagnostics[] = [];
+    const lines = s.split('\n');
+
+    const p = /^(?:(?<error>E\d+)|(?<warning>W\d+))\s(?<line>\d+):(?<col>\d+)\s(?<message>.+)$/;
+
+    for (const v of lines) {
+      let ruleName: string | undefined;
+      let line: number | undefined;
+      let col: number | undefined;
+      let message: string | undefined;
+
+      const m = v.match(p);
+      if (m) {
+        if (m.groups?.error) {
+          ruleName = m.groups.error;
+        } else if (m.groups?.warning) {
+          ruleName = m.groups.warning;
+        }
+
+        line = m.groups?.line ? Number(m.groups.line) : undefined;
+        col = m.groups?.col ? Number(m.groups.col) : undefined;
+        message = m.groups?.message ? m.groups.message : undefined;
+      }
+
+      if (ruleName !== undefined && line !== undefined && col !== undefined && message !== undefined) {
+        diagnostics.push({
+          ruleName,
+          line,
+          col,
+          message,
+        });
+      }
+    }
+
+    return diagnostics;
+  }
+
+  public getSeverity(s: string) {
+    let severity: DiagnosticSeverity;
+    let severityNumber: number | undefined;
+
+    if (s.startsWith('W')) {
+      severityNumber = DiagnosticSeverity.Warning;
+    }
+
+    if (s.startsWith('E')) {
+      severityNumber = DiagnosticSeverity.Error;
+    }
+
+    switch (severityNumber) {
+      case 1:
+        severity = DiagnosticSeverity.Error;
+        break;
+
+      case 2:
+        severity = DiagnosticSeverity.Warning;
+        break;
+
+      default:
+        severity = DiagnosticSeverity.Error;
+        break;
+    }
+
+    return severity;
+  }
+}

--- a/src/tool.ts
+++ b/src/tool.ts
@@ -35,6 +35,28 @@ export function resolveDjhtmlPath(context: ExtensionContext, toolPath: string): 
   return toolPath;
 }
 
+export function resolveDjlintPath(context: ExtensionContext, toolPath: string): string {
+  if (!toolPath) {
+    const whichDjlint = whichCmd('djlint');
+    if (whichDjlint) {
+      toolPath = whichDjlint;
+    } else if (
+      fs.existsSync(path.join(context.storagePath, 'htmldjango', 'venv', 'Scripts', 'djlint.exe')) ||
+      fs.existsSync(path.join(context.storagePath, 'htmldjango', 'venv', 'bin', 'djlint'))
+    ) {
+      if (process.platform === 'win32') {
+        toolPath = path.join(context.storagePath, 'htmldjango', 'venv', 'Scripts', 'djlint.exe');
+      } else {
+        toolPath = path.join(context.storagePath, 'htmldjango', 'venv', 'bin', 'djlint');
+      }
+    } else {
+      toolPath = '';
+    }
+  }
+
+  return toolPath;
+}
+
 export function getPythonPath(config: WorkspaceConfiguration, isRealpath?: boolean): string {
   let pythonPath = config.get<string>('builtin.pythonPath', '');
   if (pythonPath) {


### PR DESCRIPTION
## Overview

### Tools

Add support for djlint integration (linter and formatter).

- [Riverside-Healthcare/djlint](https://github.com/Riverside-Healthcare/djlint) for python

## DEMO

> "htmldjango.djlint.enable": true (default false)

https://user-images.githubusercontent.com/188642/134280747-18762002-db66-4c30-9962-51d6060ef385.mp4

## Summary

### Add options

- `htmldjango.formatting.provider`: Provider for formatting. Possible options include 'djhtml', 'djlint', and 'none', default: `"djhtml"`
- `htmldjango.djlint.commandPath`: The custom path to the djlint (Absolute path), default: `""`
- `htmldjango.djlint.enable`: Enable djLint (diagnostics), default: `false`
- `htmldjango.djlint.lintOnOpen`: Lint file on opening, default: `true`
- `htmldjango.djlint.lintOnChange`: Lint file on change, default: `true`
- `htmldjango.djlint.lintOnSave`: Lint file on save, default: `true`

### Add commands

- `htmldjango.djlint.format`

### builtin install

Change `htmldjango.builtin.installTools` commands to install `djlint` with it.

```
:CocComannd htmldjango.builtin.installTools
```

## Thanks

- Thanks, stdin support 
  - <https://github.com/Riverside-Healthcare/djLint/issues/13>