### PR TITLE
feat: add "htmldjango.djlint.indent" option

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Plug 'yaegassy/coc-htmldjango', {'do': 'yarn install --frozen-lockfile'}
 - `htmldjango.djlint.lintOnChange`: Lint file on change, default: `true`
 - `htmldjango.djlint.lintOnSave`: Lint file on save, default: `true`
 - `htmldjango.djlint.ignore`: Codes to ignore (`--ignore`), ex: "W013,W014", default: `""`
+- `htmldjango.djlint.indent`: Indent spacing (`--indent`), default: `4`
 
 ## Commands
 

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   "devDependencies": {
     "@types/node": "^14.6.3",
     "@types/rimraf": "^3.0.0",
+    "@types/semver": "^7.3.8",
     "@types/tmp": "^0.2.0",
     "@types/which": "^2.0.0",
     "@typescript-eslint/eslint-plugin": "^4.8.2",
@@ -51,6 +52,7 @@
     "eslint-plugin-prettier": "^3.1.4",
     "prettier": "^2.2.0",
     "rimraf": "^3.0.2",
+    "semver": "^7.3.5",
     "tmp": "^0.1.0",
     "ts-node": "^9.1.1",
     "typescript": "^4.1.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "coc-htmldjango",
   "version": "0.6.2",
-  "djlintVersion": "0.4.2",
+  "djlintVersion": "0.4.4",
   "djhtmlVersion": "1.4.9",
   "description": "django templates (htmldjango) extension for coc.nvim. Provides formatter, snippets completion and more...",
   "author": "yaegassy <yosstools@gmail.com>",

--- a/package.json
+++ b/package.json
@@ -142,6 +142,11 @@
           "type": "string",
           "default": "",
           "description": "Codes to ignore (--ignore)"
+        },
+        "htmldjango.djlint.indent": {
+          "type": "number",
+          "default": 4,
+          "description": "Indent spacing (--indent)"
         }
       }
     },

--- a/src/tool.ts
+++ b/src/tool.ts
@@ -5,6 +5,11 @@ import path from 'path';
 
 import which from 'which';
 
+import child_process from 'child_process';
+import util from 'util';
+
+const exec = util.promisify(child_process.exec);
+
 export function whichCmd(cmd: string): string {
   try {
     return which.sync(cmd);
@@ -84,4 +89,17 @@ export function getPythonPath(config: WorkspaceConfiguration, isRealpath?: boole
   }
 
   return pythonPath;
+}
+
+export async function getToolVersion(command: string): Promise<string | undefined> {
+  const versionCmd = `${command} --version`;
+  let versionStr = '';
+  try {
+    await exec(versionCmd).then((value) => {
+      versionStr = value.stdout.trim();
+    });
+    return versionStr;
+  } catch (error) {
+    return undefined;
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -95,6 +95,11 @@
     "@types/glob" "*"
     "@types/node" "*"
 
+"@types/semver@^7.3.8":
+  version "7.3.8"
+  resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.3.8.tgz#508a27995498d7586dcecd77c25e289bfaf90c59"
+  integrity sha512-D/2EJvAlCEtYFEYmmlGwbGXuK886HzyCc3nZX/tkFTQdEU8jZDAgiv08P162yB17y4ZXZoq7yFAnW4GDBb9Now==
+
 "@types/tmp@^0.2.0":
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/@types/tmp/-/tmp-0.2.0.tgz#e3f52b4d7397eaa9193592ef3fdd44dc0af4298c"
@@ -933,7 +938,7 @@ run-parallel@^1.1.9:
   dependencies:
     queue-microtask "^1.2.2"
 
-semver@^7.2.1, semver@^7.3.2:
+semver@^7.2.1, semver@^7.3.2, semver@^7.3.5:
   version "7.3.5"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.5.tgz#0b621c879348d8998e4b0e4be94b3f12e6018ef7"
   integrity sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==


### PR DESCRIPTION
Close https://github.com/yaegassy/coc-htmldjango/issues/8

- `htmldjango.djlint.indent` option works with djlint v0.4.4 and later.
- In lower versions, the option will be skipped.

Thanks, @christopherpickering

- <https://github.com/Riverside-Healthcare/djLint/issues/29>
