### PR TITLE
feat: add completion feature via CompletionItemProvider

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,10 @@ django templates (htmldjango) extension for [coc.nvim](https://github.com/neocli
   - by [djLint](https://github.com/Riverside-Healthcare/djlint) (reformat HTML templates)
 - Lint (default: `false`)
   - by [djLint](https://github.com/Riverside-Healthcare/djlint) (Find common formatting issues) | [DEMO](https://github.com/yaegassy/coc-htmldjango/pull/6)
+- Completion
+  - Completion of snippets data via `completionItemProvider`
 - Hover | [DEMO](https://github.com/yaegassy/coc-htmldjango/pull/1)
 - CodeAction | [DEMO](https://github.com/yaegassy/coc-htmldjango/pull/3)
-- Snippets completion
-  - To use it, you need to install [coc-snippets](https://github.com/neoclide/coc-snippets).
-  - And set `snippets.loadFromExtensions` to true in "coc-settings.json"
 - Built-in installer (DjHTML, djLint)
 
 ## Install
@@ -35,11 +34,12 @@ Plug 'yaegassy/coc-htmldjango', {'do': 'yarn install --frozen-lockfile'}
 **Recommended coc extension**:
 
 - [coc-html](https://github.com/neoclide/coc-html)
-- [coc-snippets](https://github.com/neoclide/coc-snippets)
 
 ## Configuration options for coc-htmldjango
 
 - `htmldjango.enable`: Enable coc-htmldjango extension, default: `true`
+- `htmldjango.completion.enable`: Enable snippets completion, default: `true`
+- `htmldjango.completion.exclude`: Exclude specific key in snippet completion, default: `["autoescape_paste", "comment_paste", "comment_selection", "for_paste", "forempty_paste", "if_paste", "ifelse_paste", "spaceless_paste", "verbatim_paste", "with_selection", "with_paste", "trans_paste", "blocktrans_paste", "blocktrans_with_paste"]`
 - `htmldjango.builtin.pythonPath`: Python 3.x path (Absolute path) to be used for built-in install, default: `""`
 - `htmldjango.formatting.provider`: Provider for formatting. Possible options include 'djhtml', 'djlint', and 'none', default: `"djhtml"`
 - `htmldjango.djhtml.commandPath`: The custom path to the djhtml (Absolute path), default: `""`

--- a/package.json
+++ b/package.json
@@ -163,16 +163,6 @@
         "command": "htmldjango.djlint.format",
         "title": "djLint format"
       }
-    ],
-    "snippets": [
-      {
-        "language": "htmldjango",
-        "path": "./snippets/tags.json"
-      },
-      {
-        "language": "htmldjango",
-        "path": "./snippets/filters.json"
-      }
     ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -79,6 +79,31 @@
           "default": true,
           "description": "Enable coc-htmldjango extension"
         },
+        "htmldjango.completion.enable": {
+          "type": "boolean",
+          "default": true,
+          "description": "Enable snippets completion"
+        },
+        "htmldjango.completion.exclude": {
+          "type": "array",
+          "default": [
+            "autoescape_paste",
+            "comment_paste",
+            "comment_selection",
+            "for_paste",
+            "forempty_paste",
+            "if_paste",
+            "ifelse_paste",
+            "spaceless_paste",
+            "verbatim_paste",
+            "with_selection",
+            "with_paste",
+            "trans_paste",
+            "blocktrans_paste",
+            "blocktrans_with_paste"
+          ],
+          "description": "Exclude specific key in snippet completion"
+        },
         "htmldjango.hoverLang": {
           "type": "string",
           "default": "django",

--- a/src/completion/filtersSnippetsCompletion.ts
+++ b/src/completion/filtersSnippetsCompletion.ts
@@ -1,0 +1,99 @@
+import {
+  CancellationToken,
+  CompletionContext,
+  CompletionItem,
+  CompletionItemKind,
+  CompletionItemProvider,
+  CompletionList,
+  ExtensionContext,
+  InsertTextFormat,
+  Position,
+  TextDocument,
+  workspace,
+} from 'coc.nvim';
+
+import path from 'path';
+import fs from 'fs';
+
+type SnippetsJsonType = {
+  [key: string]: {
+    description: string;
+    prefix: string;
+    body: string | string[];
+  };
+};
+
+export class FiltersSnippetsCompletionProvider implements CompletionItemProvider {
+  private _context: ExtensionContext;
+  private snippetsFilePath: string;
+  private excludeSnippetsKeys: string[];
+
+  constructor(context: ExtensionContext) {
+    this._context = context;
+    this.snippetsFilePath = path.join(this._context.extensionPath, 'snippets', 'filters.json');
+    this.excludeSnippetsKeys = workspace.getConfiguration('htmldjango').get<string[]>('completion.exclude', []);
+  }
+
+  async getSnippetsCompletionItems(snippetsFilePath: string) {
+    const snippetsCompletionList: CompletionItem[] = [];
+    if (fs.existsSync(snippetsFilePath)) {
+      const snippetsJsonText = fs.readFileSync(snippetsFilePath, 'utf8');
+      const snippetsJson: SnippetsJsonType = JSON.parse(snippetsJsonText);
+      if (snippetsJson) {
+        Object.keys(snippetsJson).map((key) => {
+          // Check exclude
+          if (this.excludeSnippetsKeys.includes(key)) return;
+
+          let snippetsText: string;
+          const body = snippetsJson[key].body;
+          if (body instanceof Array) {
+            snippetsText = body.join('\n');
+          } else {
+            snippetsText = body;
+          }
+
+          // In coc-htmldjango, insertText is handled by resolveCompletionItem.
+          // In provideCompletionItems, if insertText contains only snippets data,
+          // it will be empty when the candidate is selected.
+          snippetsCompletionList.push({
+            label: snippetsJson[key].prefix,
+            kind: CompletionItemKind.Snippet,
+            filterText: snippetsJson[key].prefix,
+            detail: snippetsJson[key].description,
+            documentation: snippetsText,
+            insertTextFormat: InsertTextFormat.Snippet,
+            // The "snippetsText" that will eventually be added to the insertText
+            // will be stored in the "data" key
+            data: snippetsText,
+          });
+        });
+      }
+    }
+
+    return snippetsCompletionList;
+  }
+
+  async provideCompletionItems(
+    document: TextDocument,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    position: Position,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    token: CancellationToken,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    context: CompletionContext
+  ): Promise<CompletionItem[] | CompletionList> {
+    const doc = workspace.getDocument(document.uri);
+    if (!doc) return [];
+
+    const completionList = this.getSnippetsCompletionItems(this.snippetsFilePath);
+
+    return completionList;
+  }
+
+  async resolveCompletionItem(item: CompletionItem): Promise<CompletionItem> {
+    if (item.kind === CompletionItemKind.Snippet) {
+      item.insertText = item.data;
+    }
+    return item;
+  }
+}

--- a/src/completion/tagsSnippetsCompletion.ts
+++ b/src/completion/tagsSnippetsCompletion.ts
@@ -1,0 +1,99 @@
+import {
+  CancellationToken,
+  CompletionContext,
+  CompletionItem,
+  CompletionItemKind,
+  CompletionItemProvider,
+  CompletionList,
+  ExtensionContext,
+  InsertTextFormat,
+  Position,
+  TextDocument,
+  workspace,
+} from 'coc.nvim';
+
+import path from 'path';
+import fs from 'fs';
+
+type SnippetsJsonType = {
+  [key: string]: {
+    description: string;
+    prefix: string;
+    body: string | string[];
+  };
+};
+
+export class TagsSnippetsCompletionProvider implements CompletionItemProvider {
+  private _context: ExtensionContext;
+  private snippetsFilePath: string;
+  private excludeSnippetsKeys: string[];
+
+  constructor(context: ExtensionContext) {
+    this._context = context;
+    this.snippetsFilePath = path.join(this._context.extensionPath, 'snippets', 'tags.json');
+    this.excludeSnippetsKeys = workspace.getConfiguration('htmldjango').get<string[]>('completion.exclude', []);
+  }
+
+  async getSnippetsCompletionItems(snippetsFilePath: string) {
+    const snippetsCompletionList: CompletionItem[] = [];
+    if (fs.existsSync(snippetsFilePath)) {
+      const snippetsJsonText = fs.readFileSync(snippetsFilePath, 'utf8');
+      const snippetsJson: SnippetsJsonType = JSON.parse(snippetsJsonText);
+      if (snippetsJson) {
+        Object.keys(snippetsJson).map((key) => {
+          // Check exclude
+          if (this.excludeSnippetsKeys.includes(key)) return;
+
+          let snippetsText: string;
+          const body = snippetsJson[key].body;
+          if (body instanceof Array) {
+            snippetsText = body.join('\n');
+          } else {
+            snippetsText = body;
+          }
+
+          // In coc-htmldjango, insertText is handled by resolveCompletionItem.
+          // In provideCompletionItems, if insertText contains only snippets data,
+          // it will be empty when the candidate is selected.
+          snippetsCompletionList.push({
+            label: snippetsJson[key].prefix,
+            kind: CompletionItemKind.Snippet,
+            filterText: snippetsJson[key].prefix,
+            detail: snippetsJson[key].description,
+            documentation: snippetsText,
+            insertTextFormat: InsertTextFormat.Snippet,
+            // The "snippetsText" that will eventually be added to the insertText
+            // will be stored in the "data" key
+            data: snippetsText,
+          });
+        });
+      }
+    }
+
+    return snippetsCompletionList;
+  }
+
+  async provideCompletionItems(
+    document: TextDocument,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    position: Position,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    token: CancellationToken,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    context: CompletionContext
+  ): Promise<CompletionItem[] | CompletionList> {
+    const doc = workspace.getDocument(document.uri);
+    if (!doc) return [];
+
+    const completionList = this.getSnippetsCompletionItems(this.snippetsFilePath);
+
+    return completionList;
+  }
+
+  async resolveCompletionItem(item: CompletionItem): Promise<CompletionItem> {
+    if (item.kind === CompletionItemKind.Snippet) {
+      item.insertText = item.data;
+    }
+    return item;
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,8 @@ import { installTools } from './installer';
 import { resolveDjhtmlPath, resolveDjlintPath, getPythonPath } from './tool';
 import { HtmlDjangoCodeActionProvider } from './action';
 import { LintEngine } from './lint';
+import { TagsSnippetsCompletionProvider } from './completion/tagsSnippetsCompletion';
+import { FiltersSnippetsCompletionProvider } from './completion/filtersSnippetsCompletion';
 
 interface Selectors {
   rangeLanguageSelector: DocumentSelector;
@@ -179,6 +181,25 @@ export async function activate(context: ExtensionContext): Promise<void> {
         subscriptions
       );
     }
+  }
+
+  const isEnableCompletion = extensionConfig.get<boolean>('completion.enable', true);
+  if (isEnableCompletion) {
+    context.subscriptions.push(
+      languages.registerCompletionItemProvider(
+        'htmldjango-tags',
+        'DJTags',
+        ['htmldjango'],
+        new TagsSnippetsCompletionProvider(context)
+      ),
+      languages.registerCompletionItemProvider(
+        'htmldjango-filters',
+        'DJFilters',
+        ['htmldjango'],
+        new FiltersSnippetsCompletionProvider(context),
+        ['|']
+      )
+    );
   }
 }
 


### PR DESCRIPTION
## Summary

In coc-htmldjango, snippets are configured in contributes.snippets, and snippet completion works in conjunction with coc-snippets.

However, there is a problem with this, for example, if you want to disable the snippet completion provided by coc-htmldjango itself, you cannot.

In some cases, you may want to disable it, especially if you are using your own snippets.

Switch to using `CompletionItemProvider` to provide completion feature.

## DEMO(mp4)

https://user-images.githubusercontent.com/188642/135200505-41cae279-79ad-42f0-91e6-0f2e51f22852.mp4

## Add configuration options

- `htmldjango.completion.enable`: Enable snippets completion, default: `true`
- `htmldjango.completion.exclude`: Exclude specific key in snippet completion, default: `["autoescape_paste", "comment_paste", "comment_selection", "for_paste", "forempty_paste", "if_paste", "ifelse_paste", "spaceless_paste", "verbatim_paste", "with_selection", "with_paste", "trans_paste", "blocktrans_paste", "blocktrans_with_paste"]`

