### PR TITLE
feat(codeaction): add "ignore code block tag" action for djlint

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Plug 'yaegassy/coc-htmldjango', {'do': 'yarn install --frozen-lockfile'}
 - `htmldjango.djhtml.commandPath`: The custom path to the djhtml (Absolute path), default: `""`
 - `htmldjango.djhtml.tabWidth`: Set tabwidth (--tabwidth), default: `4`
 - `htmldjango.djlint.commandPath`: The custom path to the djlint (Absolute path), default: `""`
-- `htmldjango.djlint.enable`: Enable djLint (diagnostics), default: `false`
+- `htmldjango.djlint.enableLint`: Enable djLint lint (diagnostics), default: `false`
 - `htmldjango.djlint.lintOnOpen`: Lint file on opening, default: `true`
 - `htmldjango.djlint.lintOnChange`: Lint file on change, default: `true`
 - `htmldjango.djlint.lintOnSave`: Lint file on save, default: `true`

--- a/README.md
+++ b/README.md
@@ -69,8 +69,12 @@ nmap <silent> ga <Plug>(coc-codeaction-line)
 
 **Actions**:
 
-- `Add {# fmt:off #} for this line`
-- `Add {# fmt:on #} for this line`
+- If `htmldjango.formatting.provider` is `djhtml`
+  - `Add {# fmt:off #} for this line`
+  - `Add {# fmt:on #} for this line`
+- If `htmldjango.formatting.provider` is `djlint` or If `htmldjango.djlint.enableLint` is `true`
+  - `Add {% djlint:off %} for this line`
+  - `Add {% djlint:on %} for this line`
 
 ## Bult-in install (DjHTML, djLint)
 

--- a/src/action.ts
+++ b/src/action.ts
@@ -10,6 +10,15 @@ import {
 } from 'coc.nvim';
 
 export class HtmlDjangoCodeActionProvider implements CodeActionProvider {
+  private formattingProvider: string | undefined;
+  djlintEnableLint: boolean;
+
+  constructor() {
+    const extConfig = workspace.getConfiguration('htmldjango');
+    this.formattingProvider = extConfig.get<string>('formatting.provider');
+    this.djlintEnableLint = extConfig.get<boolean>('djlint.enableLint', true);
+  }
+
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   public async provideCodeActions(document: TextDocument, range: Range, context: CodeActionContext) {
     const doc = workspace.getDocument(document.uri);
@@ -26,56 +35,118 @@ export class HtmlDjangoCodeActionProvider implements CodeActionProvider {
     }
     const codeActions: CodeAction[] = [];
 
-    /** Add {# fmt:off #} for this line (htmldjango) */
-    if (this.lineRange(range)) {
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      const line = doc.getline(range.start.line);
+    //
+    // djhtml
+    //
+    if (this.formattingProvider === 'djhtml') {
+      /** Add {# fmt:off #} for this line (htmldjango) */
+      if (this.lineRange(range)) {
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        const line = doc.getline(range.start.line);
 
-      const thisLineFullLength = doc.getline(range.start.line).length;
-      const thisLineTrimLength = doc.getline(range.start.line).trim().length;
-      const suppressLineLength = thisLineFullLength - thisLineTrimLength;
+        const thisLineFullLength = doc.getline(range.start.line).length;
+        const thisLineTrimLength = doc.getline(range.start.line).trim().length;
+        const suppressLineLength = thisLineFullLength - thisLineTrimLength;
 
-      let suppressLineNewText = '{# fmt:off #}\n';
-      if (suppressLineLength > 0) {
-        const addIndentSpace = ' '.repeat(suppressLineLength);
-        suppressLineNewText = '{# fmt:off #}\n' + addIndentSpace;
+        let suppressLineNewText = '{# fmt:off #}\n';
+        if (suppressLineLength > 0) {
+          const addIndentSpace = ' '.repeat(suppressLineLength);
+          suppressLineNewText = '{# fmt:off #}\n' + addIndentSpace;
+        }
+
+        const edit = TextEdit.insert(Position.create(range.start.line, suppressLineLength), suppressLineNewText);
+        codeActions.push({
+          title: 'Add {# fmt:off #} for this line',
+          edit: {
+            changes: {
+              [doc.uri]: [edit],
+            },
+          },
+        });
       }
 
-      const edit = TextEdit.insert(Position.create(range.start.line, suppressLineLength), suppressLineNewText);
-      codeActions.push({
-        title: 'Add {# fmt:off #} for this line',
-        edit: {
-          changes: {
-            [doc.uri]: [edit],
+      /** Add {# fmt:on #} for this line (htmldjango) */
+      if (this.lineRange(range)) {
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        const line = doc.getline(range.start.line);
+
+        const thisLineFullLength = doc.getline(range.start.line).length;
+        const thisLineTrimLength = doc.getline(range.start.line).trim().length;
+        const suppressLineLength = thisLineFullLength - thisLineTrimLength;
+
+        let suppressLineNewText = '{# fmt:on #}\n';
+        if (suppressLineLength > 0) {
+          const addIndentSpace = ' '.repeat(suppressLineLength);
+          suppressLineNewText = '{# fmt:on #}\n' + addIndentSpace;
+        }
+
+        const edit = TextEdit.insert(Position.create(range.start.line, suppressLineLength), suppressLineNewText);
+        codeActions.push({
+          title: 'Add {# fmt:on #} for this line',
+          edit: {
+            changes: {
+              [doc.uri]: [edit],
+            },
           },
-        },
-      });
+        });
+      }
     }
 
-    /** Add {# fmt:on #} for this line (htmldjango) */
-    if (this.lineRange(range)) {
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      const line = doc.getline(range.start.line);
+    //
+    // djlint
+    //
+    if (this.formattingProvider === 'djlint' || this.djlintEnableLint) {
+      /** Add {% djlint:off %} for this line (htmldjango) */
+      if (this.lineRange(range)) {
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        const line = doc.getline(range.start.line);
 
-      const thisLineFullLength = doc.getline(range.start.line).length;
-      const thisLineTrimLength = doc.getline(range.start.line).trim().length;
-      const suppressLineLength = thisLineFullLength - thisLineTrimLength;
+        const thisLineFullLength = doc.getline(range.start.line).length;
+        const thisLineTrimLength = doc.getline(range.start.line).trim().length;
+        const suppressLineLength = thisLineFullLength - thisLineTrimLength;
 
-      let suppressLineNewText = '{# fmt:on #}\n';
-      if (suppressLineLength > 0) {
-        const addIndentSpace = ' '.repeat(suppressLineLength);
-        suppressLineNewText = '{# fmt:on #}\n' + addIndentSpace;
+        let suppressLineNewText = '{% djlint:off %}\n';
+        if (suppressLineLength > 0) {
+          const addIndentSpace = ' '.repeat(suppressLineLength);
+          suppressLineNewText = '{% djlint:off %}\n' + addIndentSpace;
+        }
+
+        const edit = TextEdit.insert(Position.create(range.start.line, suppressLineLength), suppressLineNewText);
+        codeActions.push({
+          title: 'Add {% djlint:off %} for this line',
+          edit: {
+            changes: {
+              [doc.uri]: [edit],
+            },
+          },
+        });
       }
 
-      const edit = TextEdit.insert(Position.create(range.start.line, suppressLineLength), suppressLineNewText);
-      codeActions.push({
-        title: 'Add {# fmt:on #} for this line',
-        edit: {
-          changes: {
-            [doc.uri]: [edit],
+      /** Add {% djlint:on %} for this line (htmldjango) */
+      if (this.lineRange(range)) {
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        const line = doc.getline(range.start.line);
+
+        const thisLineFullLength = doc.getline(range.start.line).length;
+        const thisLineTrimLength = doc.getline(range.start.line).trim().length;
+        const suppressLineLength = thisLineFullLength - thisLineTrimLength;
+
+        let suppressLineNewText = '{% djlint:on %}\n';
+        if (suppressLineLength > 0) {
+          const addIndentSpace = ' '.repeat(suppressLineLength);
+          suppressLineNewText = '{% djlint:on %}\n' + addIndentSpace;
+        }
+
+        const edit = TextEdit.insert(Position.create(range.start.line, suppressLineLength), suppressLineNewText);
+        codeActions.push({
+          title: 'Add {% djlint:on %} for this line',
+          edit: {
+            changes: {
+              [doc.uri]: [edit],
+            },
           },
-        },
-      });
+        });
+      }
     }
 
     return codeActions;

--- a/src/action.ts
+++ b/src/action.ts
@@ -11,7 +11,7 @@ import {
 
 export class HtmlDjangoCodeActionProvider implements CodeActionProvider {
   private formattingProvider: string | undefined;
-  djlintEnableLint: boolean;
+  private djlintEnableLint: boolean;
 
   constructor() {
     const extConfig = workspace.getConfiguration('htmldjango');


### PR DESCRIPTION
## Description

Add the ability to insert djlint's `{% djlint:off %}` and `{% djlint:on %}`.

**REF: djlint v0.5.0**:

> Added option to ignore code block from linter/formatter with {% djlint:off %}...{% djlint:on %} tags

## DEMO (mp4)

https://user-images.githubusercontent.com/188642/135842807-1109b1cb-f49f-42ba-bd01-f352b239c853.mp4
