### PR TITLE
feat(command): add "htmldjango.showOutput" command

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Plug 'yaegassy/coc-htmldjango', {'do': 'yarn install --frozen-lockfile'}
 
 ## Commands
 
+- `htmldjango.showOutput`
 - `htmldjango.builtin.installTools`
 - `htmldjango.djhtml.format`
 - `htmldjango.djlint.format`

--- a/package.json
+++ b/package.json
@@ -196,6 +196,10 @@
     },
     "commands": [
       {
+        "command": "htmldjango.showOutput",
+        "title": "Show htmldjango output channel"
+      },
+      {
         "command": "htmldjango.builtin.installTools",
         "title": "Install htmldjango related tools"
       },

--- a/src/index.ts
+++ b/src/index.ts
@@ -66,6 +66,15 @@ export async function activate(context: ExtensionContext): Promise<void> {
   const isRealpath = true;
   const pythonCommand = getPythonPath(extensionConfig, isRealpath);
 
+  // htmldjango.showOutput command
+  context.subscriptions.push(
+    commands.registerCommand('htmldjango.showOutput', () => {
+      if (outputChannel) {
+        outputChannel.show();
+      }
+    })
+  );
+
   subscriptions.push(
     commands.registerCommand('htmldjango.builtin.installTools', async () => {
       await installWrapper(pythonCommand, context);


### PR DESCRIPTION
Quickly display the log output screen of coc-htmldjango's linter and formatter.

- `:CocCommand htmldjango.showOutput`

<img width="714" alt="coc-htmldjango-show-output-command" src="https://user-images.githubusercontent.com/188642/151911866-238507e8-55dd-483a-800c-3f2537c9c186.png">

