### PR TITLE
Add "htmldjango.showReferences" command

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ django templates (htmldjango) extension for [coc.nvim](https://github.com/neocli
   - Completion of snippets data via `completionItemProvider`
 - Hover | [DEMO](https://github.com/yaegassy/coc-htmldjango/pull/1)
 - CodeAction | [DEMO](https://github.com/yaegassy/coc-htmldjango/pull/3)
+- Commands
 - Built-in installer (djLint, DjHTML)
 
 ## Install
@@ -73,10 +74,11 @@ Plug 'yaegassy/coc-htmldjango', {'do': 'yarn install --frozen-lockfile'}
 
 ## Commands
 
-- `htmldjango.showOutput`
-- `htmldjango.builtin.installTools`
-- `htmldjango.djlint.format`
-- `htmldjango.djhtml.format`
+- `htmldjango.showOutput`: Show htmldjango output channel
+- `htmldjango.builtin.installTools`: Install htmldjango related tools
+- `htmldjango.djlint.format`: Run djLint format
+- `htmldjango.djhtml.format`: Run DjHTML format
+- `htmldjango.showReferences`: Show  Variables Block (`{{ ... }}`) or TemplateTags Block (`{% ... %}`) location information for the current file
 
 ## Code Actions
 

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "semi": true
   },
   "devDependencies": {
+    "@types/mustache": "^4.2.2",
     "@types/node": "^18.16.1",
     "@types/rimraf": "^3.0.2",
     "@types/semver": "^7.3.10",
@@ -257,15 +258,20 @@
       },
       {
         "command": "htmldjango.djlint.format",
-        "title": "djLint format"
+        "title": "Run djLint format"
       },
       {
         "command": "htmldjango.djhtml.format",
-        "title": "DjHTML format"
+        "title": "Run DjHTML format"
+      },
+      {
+        "command": "htmldjango.showReferences",
+        "title": "Show  Variables Block (`{{ ... }}`) or TemplateTags Block (`{% ... %}`) location information for the current file"
       }
     ]
   },
   "dependencies": {
+    "mustache": "^4.2.0",
     "toml": "^3.0.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -202,6 +202,11 @@
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.4.tgz#f0ec25dbf2f0e4b18647313ac031134ca5b24b21"
   integrity sha512-1z8k4wzFnNjVK/tlxvrWuK5WMt6mydWWP7+zvH5eFep4oj+UkrfiJTRtjCeBXNpwaA/FYqqtb4/QS4ianFpIRA==
 
+"@types/mustache@^4.2.2":
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/@types/mustache/-/mustache-4.2.2.tgz#825bf5c214c3ab84d0b23fef2c8eb898f3ff8717"
+  integrity sha512-MUSpfpW0yZbTgjekDbH0shMYBUD+X/uJJJMm9LXN1d5yjl5lCY1vN/eWKD6D1tOtjA6206K0zcIPnUaFMurdNA==
+
 "@types/node@*":
   version "15.12.0"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-15.12.0.tgz#6a459d261450a300e6865faeddb5af01c3389bb3"
@@ -882,6 +887,11 @@ ms@2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
+
+mustache@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/mustache/-/mustache-4.2.0.tgz#e5892324d60a12ec9c2a73359edca52972bf6f64"
+  integrity sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==
 
 natural-compare-lite@^1.4.0:
   version "1.4.0"


### PR DESCRIPTION
## Description

I added a command to display the location information of Variables Block (`{{ ... }}`) and TemplateTags Block (`{% ... %}`).

Initially, I tried to add it as a feature of the document symbol, but a bug was found in `coc.nvim` itself that prevented it from working properly when used together with `coc-html`. It seems that the `html.filetypes` setting of `coc-html` is related to this issue...

Therefore, we have added it as a dedicated command feature.

## Command

- `htmldjango.showReferences`
  - Show  Variables Block (`{{ ... }}`) or TemplateTags Block (`{% ... %}`) location information for the current file

## DEMO (mp4)

https://user-images.githubusercontent.com/188642/234862502-c7574316-9c53-4f88-ae09-923a57b2412a.mp4
